### PR TITLE
make build (again?) against kernel 4.9(.30)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXTRA_CFLAGS += $(USER_EXTRA_CFLAGS)
-EXTRA_CFLAGS += -O1
-#EXTRA_CFLAGS += -O3
+#EXTRA_CFLAGS += -O1
+EXTRA_CFLAGS += -O3
 EXTRA_CFLAGS += -Wall
 #EXTRA_CFLAGS += -Wextra
 #EXTRA_CFLAGS += -Werror
@@ -15,6 +15,7 @@ EXTRA_CFLAGS += -Wno-unused-parameter
 EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-implicit-function-declaration
 EXTRA_CFLAGS += -Wno-unused
+#EXTRA_CFLAGS += -Wno-uninitialized
 EXTRA_CFLAGS += -Wno-error=date-time	# Fix compile error on gcc 4.9 and later
 
 EXTRA_CFLAGS += -I$(src)/include
@@ -26,24 +27,22 @@ CONFIG_AUTOCFG_CP = n
 
 ########################## WIFI IC ############################
 CONFIG_MULTIDRV = n
-CONFIG_RTL8188E = n
+CONFIG_RTL8188E = n # was n
 CONFIG_RTL8812A = y
 CONFIG_RTL8821A = y
-CONFIG_RTL8192E = n
-CONFIG_RTL8723B = n
-CONFIG_RTL8814A = n
-CONFIG_RTL8703B = n
-CONFIG_RTL8188F = n
+CONFIG_RTL8192E = n # was n
+CONFIG_RTL8723B = n # was n
+CONFIG_RTL8814A = n # was n
+CONFIG_RTL8703B = n # was n
+CONFIG_RTL8188F = n # was n
 ######################### Interface ###########################
 CONFIG_USB_HCI = y
 CONFIG_PCI_HCI = n
 CONFIG_SDIO_HCI = n
 CONFIG_GSPI_HCI = n
 ########################## Features ###########################
-# was y : Mass production tool
-CONFIG_MP_INCLUDED = n
-# was y : Power saving mode
-CONFIG_POWER_SAVING = n
+CONFIG_MP_INCLUDED = y
+CONFIG_POWER_SAVING = n # was y
 CONFIG_USB_AUTOSUSPEND = n
 CONFIG_HW_PWRP_DETECTION = n
 CONFIG_WIFI_TEST = n
@@ -52,24 +51,19 @@ CONFIG_INTEL_WIDI = n
 CONFIG_WAPI_SUPPORT = n
 CONFIG_EFUSE_CONFIG_FILE = n
 CONFIG_EXT_CLK = n
-# was y 
-CONFIG_TRAFFIC_PROTECT = n
-CONFIG_LOAD_PHY_PARA_FROM_FILE = n
+CONFIG_TRAFFIC_PROTECT = y
+CONFIG_LOAD_PHY_PARA_FROM_FILE = y
 CONFIG_CALIBRATE_TX_POWER_BY_REGULATORY = n
 CONFIG_CALIBRATE_TX_POWER_TO_MAX = n
-# was disable
-CONFIG_RTW_ADAPTIVITY_EN = enable
-# was normal
-CONFIG_RTW_ADAPTIVITY_MODE = carrier_sense
+CONFIG_RTW_ADAPTIVITY_EN = disable
+CONFIG_RTW_ADAPTIVITY_MODE = normal
 CONFIG_SIGNAL_SCALE_MAPPING = n
-# Improved security
 CONFIG_80211W = n
 CONFIG_REDUCE_TX_CPU_LOADING = n
-CONFIG_BR_EXT = n
+CONFIG_BR_EXT = y
 CONFIG_ANTENNA_DIVERSITY = n
 CONFIG_TDLS = n
-# was y
-CONFIG_WIFI_MONITOR = n
+CONFIG_WIFI_MONITOR = y
 ######################## Wake On Lan ##########################
 CONFIG_WOWLAN = n
 CONFIG_GPIO_WAKEUP = n
@@ -79,7 +73,7 @@ CONFIG_PNO_SUPPORT = n
 CONFIG_PNO_SET_DEBUG = n
 CONFIG_AP_WOWLAN = n
 ######### Notify SDIO Host Keep Power During Syspend ##########
-CONFIG_RTW_SDIO_PM_KEEP_POWER = n
+CONFIG_RTW_SDIO_PM_KEEP_POWER = y
 ###################### Platform Related #######################
 CONFIG_PLATFORM_GENERIC = y
 CONFIG_PLATFORM_I386_PC = n

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -1486,10 +1486,11 @@ _func_enter_;
 		_rtw_memcpy(pattrib->ra, pattrib->dst, ETH_ALEN);
 		_rtw_memcpy(pattrib->ta, pattrib->src, ETH_ALEN);
 
+#ifdef CONFIG_MP_INCLUDED
 		//
 		if(adapter->mppriv.bRTWSmbCfg==_FALSE)
+#endif
 			_rtw_memcpy(pattrib->bssid,  mybssid, ETH_ALEN);
-
 
 		*psta = rtw_get_stainfo(pstapriv, pattrib->bssid); // get sta_info
 		if (*psta == NULL) {
@@ -1608,8 +1609,10 @@ _func_enter_;
 		_rtw_memcpy(pattrib->bssid, GetAddr3Ptr(ptr), ETH_ALEN);
 		_rtw_memcpy(pattrib->ra, pattrib->dst, ETH_ALEN);
 		_rtw_memcpy(pattrib->ta, pattrib->src, ETH_ALEN);
+#ifdef CONFIG_MP_INCLUDED
 		//
 		if(adapter->mppriv.bRTWSmbCfg == _FALSE)
+#endif
 			_rtw_memcpy(pattrib->bssid,  mybssid, ETH_ALEN);
 
 		*psta = rtw_get_stainfo(pstapriv, pattrib->bssid); // get sta_info
@@ -3758,6 +3761,7 @@ _func_enter_;
 		len = htons(pattrib->seq_num);
 		//DBG_871X("wlan seq = %d ,seq_num =%x\n",len,pattrib->seq_num);
 		_rtw_memcpy(ptr+12,&len, 2);
+#ifdef CONFIG_MP_INCLUDED
 	if(adapter->mppriv.bRTWSmbCfg==_TRUE)
 	{
 //		if(_rtw_memcmp(mcastheadermac, pattrib->dst, 3) == _TRUE)//SimpleConfig Dest.
@@ -3767,7 +3771,7 @@ _func_enter_;
 			_rtw_memcpy(ptr, pattrib->bssid, ETH_ALEN);
 
 	}
-
+#endif
 	
 _func_exit_;	
 	return ret;
@@ -3791,8 +3795,11 @@ int mp_recv_frame(_adapter *padapter, union recv_frame *rframe)
 	struct sta_info *psta = NULL;
     	DBG_COUNTER(padapter->rx_logs.core_rx_pre);
     	
+#ifdef CONFIG_MP_INCLUDED
 	if ( (check_fwstate(pmlmepriv, _FW_LINKED) == _TRUE) )//&&(padapter->mppriv.check_mp_pkt == 0))
+#endif
 	{
+#ifdef CONFIG_MP_INCLUDED
 		if (pattrib->crc_err == 1){
 			padapter->mppriv.rx_crcerrpktcount++;
 		}
@@ -3811,6 +3818,7 @@ int mp_recv_frame(_adapter *padapter, union recv_frame *rframe)
 			goto exit;
 		}
 		else 
+#endif
 		{				
 			type =	GetFrameType(ptr);
 			pattrib->to_fr_ds = get_tofr_ds(ptr);

--- a/hal/phydm/rtl8812a/halphyrf_8812a_ce.c
+++ b/hal/phydm/rtl8812a/halphyrf_8812a_ce.c
@@ -99,7 +99,7 @@ ODM_TxPwrTrackSetPwr8812A(
 					
 					TxRate = MptToMgntRate(pMptCtx->MptRateIndex);
 			#endif
-		#elif (DM_ODM_SUPPORT_TYPE & ODM_CE)
+		#elif (DM_ODM_SUPPORT_TYPE & ODM_CE) && defined(CONFIG_MP_INCLUDED)
 				PMPT_CONTEXT pMptCtx = &(Adapter->mppriv.MptCtx);
 				
 				TxRate = MptToMgntRate(pMptCtx->MptRateIndex);
@@ -336,7 +336,7 @@ GetDeltaSwingTable_8812A(
 					
 					TxRate = MptToMgntRate(pMptCtx->MptRateIndex);
 			#endif
-		#elif (DM_ODM_SUPPORT_TYPE & ODM_CE)
+		#elif (DM_ODM_SUPPORT_TYPE & ODM_CE) && defined(CONFIG_MP_INCLUDED)
 				PMPT_CONTEXT pMptCtx = &(Adapter->mppriv.MptCtx);
 				
 				TxRate = MptToMgntRate(pMptCtx->MptRateIndex);

--- a/hal/phydm/rtl8821a/halphyrf_8821a_ce.c
+++ b/hal/phydm/rtl8821a/halphyrf_8821a_ce.c
@@ -59,10 +59,11 @@ ODM_TxPwrTrackSetPwr8821A(
 #if (DM_ODM_SUPPORT_TYPE & (ODM_WIN|ODM_CE ))
 	#if (DM_ODM_SUPPORT_TYPE & (ODM_WIN))
 		PMPT_CONTEXT		pMptCtx = &(Adapter->MptCtx);
-	#elif (DM_ODM_SUPPORT_TYPE & (ODM_CE))
-		PMPT_CONTEXT		pMptCtx = &(Adapter->mppriv.MptCtx);
-	#endif
 		TxRate = MptToMgntRate(pMptCtx->MptRateIndex);
+	#elif (DM_ODM_SUPPORT_TYPE & (ODM_CE)) && defined(CONFIG_MP_INCLUDED)
+		PMPT_CONTEXT		pMptCtx = &(Adapter->mppriv.MptCtx);
+		TxRate = MptToMgntRate(pMptCtx->MptRateIndex);
+	#endif
 #endif
 	}
 	else

--- a/hal/phydm/rtl8821a/phydm_iqk_8821a_ce.c
+++ b/hal/phydm/rtl8821a/phydm_iqk_8821a_ce.c
@@ -806,9 +806,11 @@ PHY_IQCalibrate_8821A(
 				return;
 			#endif
 		#else// (DM_ODM_SUPPORT_TYPE == ODM_CE)
+#ifdef CONFIG_MP_INCLUDED
 		PMPT_CONTEXT	pMptCtx = &(pAdapter->mppriv.MptCtx);		
 		if( pMptCtx->bSingleTone || pMptCtx->bCarrierSuppression)
 			return;
+#endif
 		 pDM_Odm->IQKFWOffload = 0; /*MP mode NO FW IQK*/
 		#endif	
 		

--- a/hal/rtl8812a/rtl8812a_hal_init.c
+++ b/hal/rtl8812a/rtl8812a_hal_init.c
@@ -1031,7 +1031,9 @@ int ReservedPage_Compare(PADAPTER Adapter,PRT_MP_FIRMWARE pFirmware,u32 BTPatchS
 	if (myBTFwBuffer == NULL)
 	{
 		DBG_871X("%s can't be executed due to the failed malloc.\n", __FUNCTION__);
+#ifdef CONFIG_MP_INCLUDED
 		Adapter->mppriv.bTxBufCkFail=_TRUE;
+#endif
 		return _FALSE;
 	}	
 	
@@ -1103,7 +1105,9 @@ int ReservedPage_Compare(PADAPTER Adapter,PRT_MP_FIRMWARE pFirmware,u32 BTPatchS
 		if(myBTFwBuffer[i]!= pFirmware->szFwBuffer[i])
 		{
 			DBG_871X(" In direct myBTFwBuffer[%d]=%x , pFirmware->szFwBuffer=%x\n",i, myBTFwBuffer[i],pFirmware->szFwBuffer[i]);
+#ifdef CONFIG_MP_INCLUDED
 			Adapter->mppriv.bTxBufCkFail=_TRUE;
+#endif
 			break;
 		}
 	}

--- a/include/rtl8812a_hal.h
+++ b/include/rtl8812a_hal.h
@@ -22,6 +22,8 @@
 
 //#include "hal_com.h"
 #include "hal_data.h"
+// for RT_MP_FIRMWARE:
+#include "rtw_mp.h"
 
 //include HAL Related header after HAL Related compiling flags 
 #include "rtl8812a_spec.h"


### PR DESCRIPTION
I just got me a USBNovel AC600 dual-band WiFi dongle (https://www.amazon.fr/dp/B06XF118RS) for which I needed an RTL881x driver. I had to make some mods to your code in order to get it to build on Kubuntu 14.04LTS with GCC 7 and the 4.9.30 kernel (stock + Kolivas patches).

I made some guesses about how to handle the `ifndef CONFIG_MP_INCLUDED` case though in the end I reverted the entire commit that deactivated that mode so I'm not entirely certain that I didn't introduce any regressions.

The dongle seems to work just fine though the Network Manager's connection editor didn't show either of my 2 5Ghz networks (nor the plasma4 applet). I cannot yet comment on connection stability.